### PR TITLE
Add support for node 8 LTS

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,7 @@
+# UNRELEASED
+
+  * add compat for node 8 LTS
+
 # 0.2.0 (2015-08-12)
 
   * add support for --release [major, minor, patch]

--- a/bin/changelog
+++ b/bin/changelog
@@ -123,7 +123,7 @@ else if (program.release) {
     // TODO detect 2 or 4 spaces (or who cares?)
     pkg.version = new_version;
     var buff = Buffer(JSON.stringify(pkg, null, 2));
-    fs.writeFileSync(pkg_filepath, buff, 0, buff.length, 0);
+    fs.writeFileSync(pkg_filepath, buff);
 
     // TODO if git commit fails, rollback versions
 


### PR DESCRIPTION
The API for `writeFileSync` seems to have changed - doesn't seem to support the options with the offset / length / pos.

I removed those extra params, hoping the API will do the right thing and read the buffer from start->end properly.

It should be backwards compatible. Checked the docs between 5 and 8:

https://nodejs.org/dist/latest-v8.x/docs/api/fs.html#fs_fs_writefilesync_file_data_options
https://nodejs.org/docs/latest-v5.x/api/fs.html#fs_fs_writefile_file_data_options_callback

Fixes this issue in node 8

```
fs.js:75
    throw new TypeError('"options" must be a string or an object, got ' +
    ^

TypeError: "options" must be a string or an object, got number instead.
    at getOptions (fs.js:75:11)
    at Object.fs.writeFileSync (fs.js:1287:13)
    at Object.<anonymous> (/Users/t.gravity/.nvm/versions/node/v8.9.1/lib/node_modules/changelog/bin/changelog:126:8)
    at Module._compile (module.js:635:30)
    at Object.Module._extensions..js (module.js:646:10)
    at Module.load (module.js:554:32)
    at tryModuleLoad (module.js:497:12)
    at Function.Module._load (module.js:489:3)
    at Function.Module.runMain (module.js:676:10)
    at startup (bootstrap_node.js:187:16)
```